### PR TITLE
KW_Board branch validating placements

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -39,7 +39,7 @@ class Board
     end
 
     def valid_placement?(ship_object, coordinate_array)
-        if coordinate_array.count == ship_object.length && consecutive_coordinates(coordinate_array)
+        if coordinate_array.count == ship_object.length && consecutive_coordinates(coordinate_array) && not_diagonal(coordinate_array)
             true
         else
             false
@@ -76,10 +76,31 @@ class Board
         false
     end
 
-    def not_diagonal(coordinate_array)
-        #can't got up alphabetically and numericall at the same time
-        #try RETRUNING FALSE WHEN consecutive_coordinates(coordinate_array)  return true only when BOTH horizontal and vertical placement conditions are met simultaneously 
+    def not_diagonal(coordinate_array)  #can't got up alphabetically and numerically at the same time
+        #try RETRUNING FALSE WHEN consecutive_coordinates(coordinate_array)
+        # return true only when BOTH horizontal and vertical placement conditions are met simultaneously 
+        coordinates_rows = coordinate_array.map do |coordinate|
+            coordinate[0]
+        end
 
+        coordinates_columns = coordinate_array.map do |coordinate|
+            coordinate[1].to_i
+        end
+
+        if coordinates_rows.all? do |row| #confirm row letters are the same
+                row != coordinates_rows[0]
+            end
+            return false
+        end
+
+        if coordinates_columns.all? do |column| #confirm column numbers are the same
+                column != coordinates_columns[0]
+            end
+            #now check if rows are consecutive, use .ord to turn letters to numbers, use .all? to return a boolean
+            return false
+        end
+
+        true
     end
 
     # def consecutive_columns(coordinate_array)

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,6 +1,5 @@
 class Board
     # attr_reader :board_hash
-
     def initialize
         # @board_hash = {
         #     "A1" => :value_1,
@@ -40,7 +39,7 @@ class Board
     end
 
     def valid_placement?(ship_object, coordinate_array)
-        if coordinate_array.count == ship_object.length && consecutive_coordinates == true
+        if coordinate_array.count == ship_object.length && consecutive_coordinates(coordinate_array)
             true
         else
             false
@@ -48,14 +47,66 @@ class Board
     end
 
     def consecutive_coordinates(coordinate_array)
-        coord_column = coordinate_array.map do |coordinate|
-            coordinate[1]
-        coord_row = coordinate_array.map do |coordinate|
-            coordinate[2].to_i
-        if coord_column.
+        coordinates_rows = coordinate_array.map do |coordinate|
+            coordinate[0]
+        end
+
+        coordinates_columns = coordinate_array.map do |coordinate|
+            coordinate[1].to_i
+        end
+
+        if coordinates_rows.all? do |row| #confirm row letters are the same
+                row == coordinates_rows[0]
+            end
+            #now check if columns are consecutive, use .all? to return a boolean
+            return coordinates_columns.each_cons(2).all? do |first, second| 
+                second == first + 1
+            end
+        end
+
+        if coordinates_columns.all? do |column| #confirm column numbers are the same
+                column == coordinates_columns[0]
+            end
+            #now check if rows are consecutive, use .ord to turn letters to numbers, use .all? to return a boolean
+            return coordinates_rows.each_cons(2).all? do |first, second|
+                second.ord == first.ord + 1
+            end
+        end
+        
+        false
     end
 
+    def not_diagonal(coordinate_array)
+        #can't got up alphabetically and numericall at the same time
+        #try RETRUNING FALSE WHEN consecutive_coordinates(coordinate_array)  return true only when BOTH horizontal and vertical placement conditions are met simultaneously 
 
+    end
 
+    # def consecutive_columns(coordinate_array)
+    #     coord_column = coordinate_array.map do |coordinate|
+    #         coordinate[0]
+    #     end
+    # end
 
+    # def consecutive_rows(coordinate_array)
+    #     coord_row = coordinate_array.map do |coordinate|
+    #         coordinate[1].to_i
+    #     end
+    # end
+
+    # def consecutive_coordinates?
+    #     if coord_column == coord_column.sort && coord_row == coord_row.sort
+    #         true
+    #     else
+    #         false
+    #     end
+    # end
+
+    # def consecutive_coordinates?
+    #     if coord_column == coord_column.sort && coord_row == coord_row.sort
+    #     #     true
+    #     # else
+    #     #     false
+    #     # end
+        
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -29,6 +29,16 @@ class Board
     }
     end
 
+    def valid_coordinate?(coordinate)
+        valid_row = ["A", "B", "C", "D"]
+        valid_line = ["1", "2", "3", "4"]
+
+        row = coordinate[0]
+        line = coordinate[1]
+        
+        coordinate.length == 2 && valid_row.include?(row) && valid_line.include?(line)
+    end
+
     def valid_placement?(ship_object, coordinate_array)
         if coordinate_array.count == ship_object.length && consecutive_coordinates == true
             true

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,5 +1,5 @@
 class Board
-    attr_reader :board_hash
+    # attr_reader :board_hash
 
     def initialize
         # @board_hash = {
@@ -28,4 +28,24 @@ class Board
             "D4" => Cell.new("D4")
     }
     end
+
+    def valid_placement?(ship_object, coordinate_array)
+        if coordinate_array.count == ship_object.length && consecutive_coordinates == true
+            true
+        else
+            false
+        end
+    end
+
+    def consecutive_coordinates(coordinate_array)
+        coord_column = coordinate_array.map do |coordinate|
+            coordinate[1]
+        coord_row = coordinate_array.map do |coordinate|
+            coordinate[2].to_i
+        if coord_column.
+    end
+
+
+
+
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -28,5 +28,28 @@ RSpec.describe Board do
             expect(board.cells.count).to eq(16)
         end
     end
+   
+    describe '#validating placements' do
+        before(:each) do
+            @board = Board.new
+            @cruiser = Ship.new("Cruiser", 3)
+            @submarine = Ship.new("Submarine", 2)
+        end
+        it 'has an arry argument that is the same length as the ship' do
+            # board = Board.new
+            # cruiser = Ship.new("Cruiser", 3)
+            # submarine = Ship.new("Submarine", 2)
+            expect(@board.valid_placement?(@cruiser, ["A1", "A2"])).to be(false)
+            expect(@board.valid_placement?(@submarine, ["A2", "A3", "A4"])).to be(false)
+        end
+
+        it 'coordinates are consecutive' do
+            # board = Board.new
+            # cruiser = Ship.new("Cruiser", 3)
+            # submarine = Ship.new("Submarine", 2)
+
+            expect(board.valid_placement?(cruiser, ["A1", "A2", "A4"])).to be(false)
+        end
+    end
 
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -65,6 +65,15 @@ RSpec.describe Board do
                 # cruiser = Ship.new("Cruiser", 3)
                 # submarine = Ship.new("Submarine", 2)
                 expect(@board.valid_placement?(@cruiser, ["A1", "A2", "A4"])).to be(false)
+                expect(@board.valid_placement?(@submarine, ["A1", "C1"])).to be(false)
+                expect(@board.valid_placement?(@cruiser, ["A3", "A2", "A1"])).to be(false)
+                expect(@board.valid_placement?(@submarine, ["C1", "B1"])).to be(false)
+            end
+
+            it 'coordinates are not diagonal' do
+                expect(@board.valid_placement?(@cruiser, ["A1", "B2", "C3"])).to be(false)
+                expect(@board.valid_placement?(@submarine, ["C2", "D3"])).to be(false)
+                expect(@board.valid_placement?(@submarine, ["C2", "C3"])).to be(true)
             end
     end
 

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -29,6 +29,23 @@ RSpec.describe Board do
         end
     end
    
+    describe '#valid_coordinate?' do
+        it 'will retrun true if coordinate is valid' do
+            board = Board.new
+
+            expect(board.valid_coordinate?("A1")).to eq true
+            expect(board.valid_coordinate?("D4")).to eq true
+        end
+
+        it 'will return false if coordinate is not valid' do
+            board = Board.new
+            binding.pry
+            expect(board.valid_coordinate?("A5")).to eq false
+            expect(board.valid_coordinate?("E1")).to eq false
+            expect(board.valid_coordinate?("A22")).to eq false
+        end
+    end
+
     describe '#validating placements' do
         before(:each) do
             @board = Board.new

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -75,6 +75,11 @@ RSpec.describe Board do
                 expect(@board.valid_placement?(@submarine, ["C2", "D3"])).to be(false)
                 expect(@board.valid_placement?(@submarine, ["C2", "C3"])).to be(true)
             end
+
+            it 'checks for valid placements' do
+                expect(@board.valid_placement?(@submarine, ["A1", "A2"])).to be(true)
+                expect(@board.valid_placement?(@cruiser, ["B1", "C1", "D1"])).to be(true)
+            end
     end
 
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe Board do
 
         it 'will return false if coordinate is not valid' do
             board = Board.new
-            binding.pry
             expect(board.valid_coordinate?("A5")).to eq false
             expect(board.valid_coordinate?("E1")).to eq false
             expect(board.valid_coordinate?("A22")).to eq false
@@ -52,21 +51,21 @@ RSpec.describe Board do
             @cruiser = Ship.new("Cruiser", 3)
             @submarine = Ship.new("Submarine", 2)
         end
-        it 'has an arry argument that is the same length as the ship' do
-            # board = Board.new
-            # cruiser = Ship.new("Cruiser", 3)
-            # submarine = Ship.new("Submarine", 2)
-            expect(@board.valid_placement?(@cruiser, ["A1", "A2"])).to be(false)
-            expect(@board.valid_placement?(@submarine, ["A2", "A3", "A4"])).to be(false)
-        end
 
-        it 'coordinates are consecutive' do
-            # board = Board.new
-            # cruiser = Ship.new("Cruiser", 3)
-            # submarine = Ship.new("Submarine", 2)
+            it 'has an arry argument that is the same length as the ship' do
+                # board = Board.new
+                # cruiser = Ship.new("Cruiser", 3)
+                # submarine = Ship.new("Submarine", 2)
+                expect(@board.valid_placement?(@cruiser, ["A1", "A2"])).to be(false)
+                expect(@board.valid_placement?(@submarine, ["A2", "A3", "A4"])).to be(false)
+            end
 
-            expect(board.valid_placement?(cruiser, ["A1", "A2", "A4"])).to be(false)
-        end
+            it 'coordinates are consecutive' do
+                # board = Board.new
+                # cruiser = Ship.new("Cruiser", 3)
+                # submarine = Ship.new("Submarine", 2)
+                expect(@board.valid_placement?(@cruiser, ["A1", "A2", "A4"])).to be(false)
+            end
     end
 
 end


### PR DESCRIPTION
This pull request adds validating ship placements methods and corresponding tests.

- the `valid_placement?(ship_object, coordinate_array)` method checks if a given set of coordinates is a valid placement for a ship by confirming the number of coordinates matches the ship length, they are consecutive, and they are not diagonal
- the `consecutive_coordinates(coordinate_array)` method verifies that the coordinates are either in the same row with consecutive columns or in the same column with consecutive rows, ensuring a valid ship placement
- the`not_diagonal(coordinate_array)` method uses the same logic as the previous method, but reverses it, ensuring that if both the rows and columns increase simultaneously then the placement is diagonal, which is not allowed, thereby prompting this method to return false
