### PR TITLE
Completed render methods for Board class and corresponding tests.

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -103,9 +103,30 @@ class Board
         end
     end
 
-    # def not_overlapping(coordinate_array)
-    #     coordinate_array.all? { |coordinate| cells[coordinate].empty?}
-    # end
+    def render(reveal = false)
+        if reveal == true 
+            p "  1 2 3 4 \n" + 
+            "A #{reveal_ship("A1")} #{reveal_ship("A2")} #{reveal_ship("A3")} #{reveal_ship("A4")} \n" +
+            "B #{reveal_ship("B1")} #{reveal_ship("B2")} #{reveal_ship("B3")} #{reveal_ship("B4")} \n" +
+            "C #{reveal_ship("C1")} #{reveal_ship("C2")} #{reveal_ship("C3")} #{reveal_ship("C4")} \n" +
+            "D #{reveal_ship("C1")} #{reveal_ship("D2")} #{reveal_ship("D3")} #{reveal_ship("D4")} \n"
+        else
+            p "  1 2 3 4 \n" + 
+            "A #{@cells["A1"].render} #{@cells["A2"].render} #{@cells["A3"].render} #{@cells["A4"].render} \n" +
+            "B #{@cells["B1"].render} #{@cells["B2"].render} #{@cells["B3"].render} #{@cells["B4"].render} \n" +
+            "C #{@cells["C1"].render} #{@cells["C2"].render} #{@cells["C3"].render} #{@cells["C4"].render} \n" +
+            "D #{@cells["C1"].render} #{@cells["D2"].render} #{@cells["D3"].render} #{@cells["D4"].render} \n"
+        end
+    end
+
+    def reveal_ship(cell_key)
+        if @cells[cell_key].fired_upon? == false && @cells[cell_key].empty? == false 
+            @cells[cell_key].render(true)
+        else 
+            @cells[cell_key].render
+        end
+    end
+
 
 
 

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -37,7 +37,7 @@ class Cell
             "."
         elsif fired_upon? == true && empty? == true
             "M"
-        elsif @ship.sunk?
+        elsif @ship && @ship.sunk?
             "X"
         elsif fired_upon? == false && empty? == false && reveal == true
             "S"

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -116,15 +116,34 @@ RSpec.describe Board do
            
 
             expect(board.valid_placement?(submarine,["A1", "B1"])).to be(false)
-
-
-            # expect(board.not_diagonal(["A1", "B1"])).to be(true)
-            # expect(cell_1.ship == cell_1.ship).to be(true)
-            # expect(cell_3.ship == cell_2.ship).to be(true)
-            # expect(cell_3.ship == cell_4.ship).to be(false)
         end
+    end
 
+    describe '#Rendering the board' do 
+        it 'render (no reveal)' do
+            board = Board.new
+            cruiser = Ship.new("Cruiser", 3) 
+            
+            board.place(cruiser, ["A1", "A2", "A3"])      
 
+            expect(board.render).to eq("  1 2 3 4 \n" +
+                "A . . . . \n" +
+                "B . . . . \n" +
+                "C . . . . \n" +
+                "D . . . . \n")       
+        end
+        it 'render (does reveal)' do
+            board = Board.new
+            cruiser = Ship.new("Cruiser", 3) 
+            
+            board.place(cruiser, ["A1", "A2", "A3"])      
+
+            expect(board.render(true)).to eq("  1 2 3 4 \n" +
+                "A S S S . \n" +
+                "B . . . . \n" +
+                "C . . . . \n" +
+                "D . . . . \n")   
+        end
     end
 
 


### PR DESCRIPTION
**Add two new methods to the Board class:**

1. render
2. reveal_ship

as well as corresponding tests to handle rendering the board in two modes: hidden and revealed.

1.  render(reveal = false):
- Displays the board grid with or without revealing ship positions.

2. If reveal is true, ship positions are displayed using the reveal_ship helper method, showing "S" where ships are present on un-fired-upon cells. Otherwise, cells are displayed without revealing ships, keeping their contents hidden until fired upon.

3. reveal_ship(cell_key):
- This helper method determines the display status of each cell based on its empty? and fired-upon state

**Tests**
Added tests in the Board RSpec file to verify both render modes:
- render (no reveal): Ensures the board displays without ship positions **by default**
- render (does reveal): Confirms ship positions display accurately when reveal is set to true.
